### PR TITLE
refactor: do not automatically import types from prelude

### DIFF
--- a/test-span-macro/src/lib.rs
+++ b/test-span-macro/src/lib.rs
@@ -21,7 +21,7 @@ pub fn test_span(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let fn_attrs = &test_fn.attrs;
 
-    let mut tracing_level = quote!(::tracing::Level::DEBUG);
+    let mut tracing_level = quote!(test_span::reexports::tracing::Level::DEBUG);
 
     // Get tracing level from #[level(tracing::Level::INFO)]
     let fn_attrs = fn_attrs
@@ -66,7 +66,8 @@ pub fn test_span(attr: TokenStream, item: TokenStream) -> TokenStream {
       #[#macro_attrs]
       #(#fn_attrs)*
       #maybe_async fn #test_name() #ret {
-        #maybe_async fn inner_test(get_telemetry: impl Fn() -> (Span, Records), get_logs: impl Fn() -> Records, get_spans: impl Fn() -> Span) #ret
+        use test_span::reexports::tracing::Instrument;
+        #maybe_async fn inner_test(get_telemetry: impl Fn() -> (test_span::Span, test_span::Records), get_logs: impl Fn() -> test_span::Records, get_spans: impl Fn() -> test_span::Span) #ret
           #body
 
 

--- a/test-span-macro/src/lib.rs
+++ b/test-span-macro/src/lib.rs
@@ -21,7 +21,7 @@ pub fn test_span(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let fn_attrs = &test_fn.attrs;
 
-    let mut tracing_level = quote!(test_span::reexports::tracing::Level::DEBUG);
+    let mut tracing_level = quote!(::test_span::reexports::tracing::Level::DEBUG);
 
     // Get tracing level from #[level(tracing::Level::INFO)]
     let fn_attrs = fn_attrs
@@ -66,8 +66,8 @@ pub fn test_span(attr: TokenStream, item: TokenStream) -> TokenStream {
       #[#macro_attrs]
       #(#fn_attrs)*
       #maybe_async fn #test_name() #ret {
-        use test_span::reexports::tracing::Instrument;
-        #maybe_async fn inner_test(get_telemetry: impl Fn() -> (test_span::Span, test_span::Records), get_logs: impl Fn() -> test_span::Records, get_spans: impl Fn() -> test_span::Span) #ret
+        use ::test_span::reexports::tracing::Instrument;
+        #maybe_async fn inner_test(get_telemetry: impl Fn() -> (::test_span::Span, ::test_span::Records), get_logs: impl Fn() -> ::test_span::Records, get_spans: impl Fn() -> ::test_span::Span) #ret
           #body
 
 
@@ -95,22 +95,22 @@ fn sync_test() -> TokenStream2 {
 }
 fn subscriber_boilerplate(level: TokenStream2) -> TokenStream2 {
     quote! {
-        test_span::init();
+        ::test_span::init();
 
         let level = &#level;
 
-        let root_span = test_span::reexports::tracing::span!(#level, "root");
+        let root_span = ::test_span::reexports::tracing::span!(#level, "root");
 
         let root_id = root_span.id().clone().expect("couldn't get root span id; this cannot happen.");
 
         #[allow(unused)]
-        let get_telemetry = || test_span::get_telemetry_for_root(&root_id, level);
+        let get_telemetry = || ::test_span::get_telemetry_for_root(&root_id, level);
 
         #[allow(unused)]
-        let get_logs = || test_span::get_logs_for_root(&root_id, level);
+        let get_logs = || ::test_span::get_logs_for_root(&root_id, level);
 
 
         #[allow(unused)]
-        let get_spans = || test_span::get_spans_for_root(&root_id, level);
+        let get_spans = || ::test_span::get_spans_for_root(&root_id, level);
     }
 }

--- a/test-span/src/lib.rs
+++ b/test-span/src/lib.rs
@@ -48,10 +48,14 @@
 //!  └───────────┘   └───────────┘
 //! ```
 
+use layer::Layer;
 use once_cell::sync::Lazy;
-use prelude::*;
 use std::sync::{Arc, Mutex};
-use tracing_subscriber::util::TryInitError;
+use tracing::{Id, Level};
+use tracing_subscriber::{
+    prelude::__tracing_subscriber_SubscriberExt,
+    util::{SubscriberInitExt, TryInitError},
+};
 type LazyMutex<T> = Lazy<Arc<Mutex<T>>>;
 
 mod attribute;
@@ -59,6 +63,9 @@ mod layer;
 mod log;
 mod record;
 mod report;
+
+pub use record::{Record, RecordValue};
+pub use report::{Records, Report, Span};
 
 static INIT: Lazy<Result<(), TryInitError>> =
     Lazy::new(|| tracing_subscriber::registry().with(Layer {}).try_init());
@@ -73,29 +80,20 @@ pub fn get_all_logs(level: &Level) -> Records {
     Records::new(logs.all_records_for_level(level))
 }
 
-pub fn get_telemetry_for_root(
-    root_id: &crate::reexports::tracing::Id,
-    level: &Level,
-) -> (Span, Records) {
+pub fn get_telemetry_for_root(root_id: &Id, level: &Level) -> (Span, Records) {
     let report = Report::from_root(root_id.into_u64());
 
     (report.spans(level), report.logs(level))
 }
 
-pub fn get_spans_for_root(root_id: &crate::reexports::tracing::Id, level: &Level) -> Span {
+pub fn get_spans_for_root(root_id: &Id, level: &Level) -> Span {
     Report::from_root(root_id.into_u64()).spans(level)
 }
 
-pub fn get_logs_for_root(root_id: &crate::reexports::tracing::Id, level: &Level) -> Records {
+pub fn get_logs_for_root(root_id: &Id, level: &Level) -> Records {
     Report::from_root(root_id.into_u64()).logs(level)
 }
 pub mod prelude {
-    pub(crate) use crate::layer::Layer;
-    pub use crate::record::RecordValue;
-    pub use crate::reexports::tracing::{Instrument, Level};
-    pub use crate::reexports::tracing_futures::WithSubscriber;
-    pub use crate::reexports::tracing_subscriber::prelude::*;
-    pub use crate::report::{Records, Report, Span};
     pub use crate::{get_all_logs, get_logs_for_root, get_spans_for_root, get_telemetry_for_root};
     pub use test_span_macro::test_span;
 }

--- a/test-span/src/lib.rs
+++ b/test-span/src/lib.rs
@@ -110,6 +110,7 @@ pub fn get_spans_for_root(root_id: &Id, level: &Level) -> Span {
 pub fn get_logs_for_root(root_id: &Id, level: &Level) -> Records {
     Report::from_root(root_id.into_u64()).logs(level)
 }
+
 pub mod prelude {
     pub use crate::{get_all_logs, get_logs_for_root, get_spans_for_root, get_telemetry_for_root};
     pub use test_span_macro::test_span;

--- a/test-span/tests/tests.rs
+++ b/test-span/tests/tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod traced_span_tests {
-    use test_span::prelude::*;
+    use test_span::reexports::tracing::Level;
+    use test_span::{prelude::*, RecordValue};
+    use tracing::Instrument;
 
     #[test_span]
     fn tracing_macro_works() {


### PR DESCRIPTION
I deleted all the import from prelude and usage of this types coming from prelude in the proc macro

Here is the main motivation:

Types which was automatically imported have the same name or common names (`Span` also exists in tracing-rs, same for `Record`, ...) which means we could have potential conflicts in naming and it's pretty annoying if you already imported `Span` from tracing-rs.

It's WIP because it needs some documentation updates and it's a proposal