### PR TITLE
fix: do not panic if test-span has already set a global subscriber.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "test-span"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "daggy",
  "derivative",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "test-span-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test-span-macro/Cargo.toml
+++ b/test-span-macro/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "test-span-macro"
 version = "0.4.0"
-authors = ["Jeremy Lempereur <jeremy@apollographql.com>", "Benjamin Coenen <benjamin.coenen@apollographql.com>"]
+authors = [
+    "Jeremy Lempereur <jeremy@apollographql.com>",
+    "Benjamin Coenen <benjamin.coenen@apollographql.com>",
+]
 edition = "2021"
 description = "macro to do snapshot tests on tracing spans, usint test-span"
 repository = "https://github.com/apollographql/test-span"

--- a/test-span-macro/Cargo.toml
+++ b/test-span-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-span-macro"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Jeremy Lempereur <jeremy@apollographql.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/test-span/Cargo.toml
+++ b/test-span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-span"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Jeremy Lempereur <jeremy@apollographql.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/test-span/Cargo.toml
+++ b/test-span/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "test-span"
 version = "0.4.0"
-authors = ["Jeremy Lempereur <jeremy@apollographql.com>", "Benjamin Coenen <benjamin.coenen@apollographql.com>"]
+authors = [
+    "Jeremy Lempereur <jeremy@apollographql.com>",
+    "Benjamin Coenen <benjamin.coenen@apollographql.com>",
+]
 edition = "2021"
 description = "macro and utilities to do snapshot tests on tracing spans"
 repository = "https://github.com/apollographql/test-span"


### PR DESCRIPTION
When running tests in parallel, test span would sometimes panic because a subscriber has already been set.
This commit makes sure we don't fail the test if the subscriber that has already been set is ours.