### PR TITLE
fix: do not change the name of the function when generating the snapshot with macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "test-span"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "daggy",
  "derivative",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "test-span-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test-span-macro/Cargo.toml
+++ b/test-span-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-span-macro"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jeremy Lempereur <jeremy@apollographql.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/test-span/Cargo.toml
+++ b/test-span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-span"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Jeremy Lempereur <jeremy@apollographql.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",


### PR DESCRIPTION

close #14