### PR TITLE
ci: SECOPS-2525 - add semgrep job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.6
+  secops: apollo/circleci-secops-orb@2.0.7
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  secops: apollo/circleci-secops-orb@2.0.6
+
 jobs:
   build:
     environment:
@@ -21,3 +24,18 @@ jobs:
           key: rust-target-v1-test-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
           paths:
             - target/
+
+workflows:
+  security-scans:
+    jobs:
+      - secops/gitleaks:
+          context:
+            - github-orb
+            - secops-oidc
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          git-revision: << pipeline.git.revision >>
+      - secops/semgrep:
+          context:
+            - github-orb
+            - secops-oidc
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>


### PR DESCRIPTION
## Motivation / Implements

This PR adds or updates the necessary configuration to enable [Semgrep](https://semgrep.dev/docs/semgrep-code/overview/) to run on PRs on this repo. The Apollo Security team uses Semgrep to test our source for potential security vulnerabilities.

Once this is accepted and merged, the Security team plans to make a passing Semgrep check a requirement for PRs to merge into this repo. This will prevent net-new severe issues from being introduced. The job proposed by this PR runs in a diff-aware mode, so it will only alert if net-new issues are introduced in a branch.

In the event that a severe issue _is_ detected on a PR, the CI job will add a comment to the PR associated with the detection to provide instructions on how to properly resolve the detection. The comment added to PRs will also include instructions on how to get further support if needed.

If maintainers reviewing this PR have questions, please reach out in the `#security` channel in Slack or contact Matt Peake directly at `matt[.]peake@apollographql[.]com`.

  

## Changed

- Updated `.circleci/config.yml` to include appropriate configuration to enable Semgrep as a CI check. 
